### PR TITLE
Increase width of side score overlayi

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -256,7 +256,7 @@ span {
 }
 #overlay-side-scores {
 	.row {
-		width: 150px;
+		width: 180px;
 	}
 	.score {
 		padding-left: 30px;


### PR DESCRIPTION
This fixes the issue where the scores overrun the boxes on the "side overlay"