### PR TITLE
Sort the league table by the league position

### DIFF
--- a/stream.html
+++ b/stream.html
@@ -196,11 +196,7 @@ overlay.scores={
             teamlist[teamlist.length] = teams[key];
         }
         function comparescore(a,b) {
-            if (a.scores.league < b.scores.league)
-                return 1;
-            if (a.scores.league > b.scores.league)
-                return -1;
-            return 0;
+            return a.league_pos - b.league_pos;
         }
 
         teamlist.sort(comparescore)


### PR DESCRIPTION
This mostly means the backend controls the ordering, which keeps a single source of truth!

Fixes #7 

![image](https://user-images.githubusercontent.com/6527489/87876288-271f5700-c9cf-11ea-97df-df52f785e771.png)
