### PR TITLE
Add an &nbsp; to the 'next match' logic.

### DIFF
--- a/stream.html
+++ b/stream.html
@@ -37,7 +37,7 @@
         <div id="match-counter" class="sbox-med flair only">
             <div class="content timer"><h2>
                 <span class="clock">?:?</span>
-                <span class="clock-info">Next Match: </span>
+                <span class="clock-info">Next Match:&nbsp;</span>
             </h2></div>
         </div>
         <div id="zones" class="hidden">


### PR DESCRIPTION
Fixes https://github.com/srobo/livestream-overlay/issues/9

(needs verifying)