### PR TITLE
Minimally cope with there not being a current match

### DIFF
--- a/stream.html
+++ b/stream.html
@@ -163,7 +163,12 @@ overlay.progressCounter={
 
     set_match: function(match)
     {
-        if(match.type=="league")
+        if(!match)
+        {
+            console.log("No current match");
+            $("#overlay-top-content .content").html('');
+        }
+        else if(match.type=="league")
         {
             $("#overlay-top-content .content").html(
                 `<p><span class="match-id">${match.display_name}</span> <span class="match-type">(league)</span></p>`


### PR DESCRIPTION
Ideally we would probably display something here, however it's not clear what that should be. Instead just log a message and remove the previous (likely incorrect) header value.