### PR TITLE
Add spacing between the clock label and the clock

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -194,6 +194,7 @@ span {
 	&.clock-info {
 		float: right;
 		margin-left: 40px;
+		margin-right: 0.15em;
 	}
 }
 #zones {


### PR DESCRIPTION
This ensures there's always some space between the "Next Match:" or "Matches resume at:" (etc.) label and the clock.

Fixes https://github.com/srobo/livestream-overlay/issues/9

With this change:
![image](https://user-images.githubusercontent.com/336212/104821976-80116000-5837-11eb-8ac3-f3de5847cd5f.png)

Without:
![image](https://user-images.githubusercontent.com/336212/104821988-8f90a900-5837-11eb-9f2c-2c640010ff28.png)
