### PR TITLE
Generalise zone support

### DIFF
--- a/stream.html
+++ b/stream.html
@@ -17,6 +17,13 @@
 </head>
 
 <body>
+<template id="corners-css">
+    .{ZONE_CLASS}::before {
+        /* Updating this? Also update $dark and/or .flair::before in style.css */
+        background: linear-gradient(to right, {ZONE_COLOUR}, #2a2a2a 50px) !important;
+    }
+</template>
+
 
 <!-- Top match info -->
 <div id="overlay-top">
@@ -42,16 +49,16 @@
         </div>
         <div id="zones" class="hidden">
             <ul>
-                <li class="sbox-small zone_0 purple">
+                <li class="sbox-small zone_0">
                     <div class="content"><p>BBC: British Broadcasting corp</p></div>
                 </li>
-                <li class="sbox-small zone_1 green">
+                <li class="sbox-small zone_1">
                     <div class="content"><p>NSA: National Security Agency</p></div>
                 </li>
-                <li class="sbox-small zone_2 yellow">
+                <li class="sbox-small zone_2">
                     <div class="content"><p>BOB: Box of Boxes</p></div>
                 </li>
-                <li class="sbox-small zone_3 orange">
+                <li class="sbox-small zone_3">
                     <div class="content"><p>RPF: Raspbery Pi Foundation</p></div>
                 </li>
             </ul>
@@ -103,19 +110,19 @@
         <div class="sbox-med flair">
             <div class="content"><h2>Up Next</h2></div>
         </div>
-        <div class="team-next sbox zone_0 purple">
+        <div class="team-next sbox zone_0">
             <div class="img"><img src="#"></div>
             <div class="name"><h2 style="">BBC</h2></div>
         </div>
-        <div class="team-next sbox zone_1 green">
+        <div class="team-next sbox zone_1">
             <div class="img"><img src="#"></div>
             <div class="name"><h2 style="">NSA</h2></div>
         </div>
-        <div class="team-next sbox zone_2 yellow">
+        <div class="team-next sbox zone_2">
             <div class="img"><img src="#"></div>
             <div class="name"><h2 style="">BOB</h2></div>
         </div>
-        <div class="team-next sbox zone_3 orange">
+        <div class="team-next sbox zone_3">
             <div class="img"><img src="#"></div>
             <div class="name"><h2 style="">RPF</h2></div>
         </div>
@@ -123,6 +130,17 @@
 </div>
 
 <script>
+
+// Yes this is pretty terrible, but it's better than nothing.
+function buildTemplate(templateQuerySelector, replacements)
+{
+    let content = document.querySelector(templateQuerySelector).innerHTML;
+    for (var name in replacements)
+    {
+        content = content.replace('{' + name + '}', replacements[name]);
+    }
+    return content;
+}
 
 cache={};
 
@@ -666,6 +684,22 @@ getNextMatch = function()
 }
 
 
+recievedCorners = function(data)
+{
+    let content = '';
+    for (var cornerID in data.corners)
+    {
+        content += buildTemplate('#corners-css', {
+            ZONE_CLASS: 'zone_' + cornerID,
+            ZONE_COLOUR: data.corners[cornerID].colour,
+        });
+    }
+    const styleNode = document.createElement('style');
+    styleNode.type = 'text/css';
+    styleNode.innerHTML = content;
+    document.head.appendChild(styleNode);
+}
+
 recievedMatches = function(matches)
 {
     //store the matches in the cache
@@ -688,7 +722,9 @@ recievedMatches = function(matches)
     overlay.progressCounter.set_match(state.currentMatch);
 }
 
+
 //on start
+comp.corners(recievedCorners);  //get the corner colours
 comp.matches(recievedMatches);  //get the match table
 
 

--- a/stream.html
+++ b/stream.html
@@ -48,6 +48,11 @@
             </h2></div>
         </div>
         <div id="zones" class="hidden">
+            <template class="zone-template">
+                <li class="sbox-small {ZONE_CLASS}">
+                    <div class="content"><p>{TEAM_NAME}</p></div>
+                </li>
+            </template>
             <ul>
                 <li class="sbox-small zone_0">
                     <div class="content"><p>BBC: British Broadcasting corp</p></div>
@@ -110,21 +115,29 @@
         <div class="sbox-med flair">
             <div class="content"><h2>Up Next</h2></div>
         </div>
-        <div class="team-next sbox zone_0">
-            <div class="img"><img src="#"></div>
-            <div class="name"><h2 style="">BBC</h2></div>
-        </div>
-        <div class="team-next sbox zone_1">
-            <div class="img"><img src="#"></div>
-            <div class="name"><h2 style="">NSA</h2></div>
-        </div>
-        <div class="team-next sbox zone_2">
-            <div class="img"><img src="#"></div>
-            <div class="name"><h2 style="">BOB</h2></div>
-        </div>
-        <div class="team-next sbox zone_3">
-            <div class="img"><img src="#"></div>
-            <div class="name"><h2 style="">RPF</h2></div>
+        <template class="zone-template">
+            <div class="team-next sbox {ZONE_CLASS}">
+                <div class="img"><img src="{IMG_SRC}"></div>
+                <div class="name"><h2>{TLA}</h2></div>
+            </div>
+        </template>
+        <div class="teams-next">
+            <div class="team-next sbox zone_0">
+                <div class="img"><img src="#"></div>
+                <div class="name"><h2 style="">BBC</h2></div>
+            </div>
+            <div class="team-next sbox zone_1">
+                <div class="img"><img src="#"></div>
+                <div class="name"><h2 style="">NSA</h2></div>
+            </div>
+            <div class="team-next sbox zone_2">
+                <div class="img"><img src="#"></div>
+                <div class="name"><h2 style="">BOB</h2></div>
+            </div>
+            <div class="team-next sbox zone_3">
+                <div class="img"><img src="#"></div>
+                <div class="name"><h2 style="">RPF</h2></div>
+            </div>
         </div>
     </div>
 </div>
@@ -250,15 +263,26 @@ overlay.next={
 
     setTeams: function(match)
     {
+        function buildZone(zone_id, tla, img_src)
+        {
+            return buildTemplate('#overlay-side-upnext .zone-template', {
+                ZONE_CLASS: 'zone_' + zone_id,
+                TLA: tla,
+                IMG_SRC: img_src,
+            });
+        }
+
         teamTLAs=match.teams;
+
+        let content = '';
+        const zonesNextContainer = document.querySelector('#overlay-side-upnext .teams-next');
 
         for (cornerID in teamTLAs)
         {
             let TLA = teamTLAs[cornerID]
             if(TLA==null || TLA=="???")
             {
-                $(".team-next.zone_"+cornerID+" h2").text("-EMPTY-");
-                $(".team-next.zone_"+cornerID+" img").attr("src","");
+                content += buildZone(cornerID, "-EMPTY-", "");
             }
             else
             {
@@ -268,10 +292,10 @@ overlay.next={
                     teamImg = imgURI+teams[TLA].image_url
                 else
                     teamImg = ""
-                $(".team-next.zone_"+cornerID+" h2").text(TLA);
-                $(".team-next.zone_"+cornerID+" img").attr("src",teamImg);
+                content += buildZone(cornerID, TLA, teamImg);
             }
         }
+        zonesNextContainer.innerHTML = content;
     }
 }
 
@@ -292,21 +316,33 @@ overlay.zones = {
     //sets the team display for a given match
     setTeams: function(match)
     {
+        function buildZone(zone_id, team_name)
+        {
+            return buildTemplate('#zones .zone-template', {
+                ZONE_CLASS: 'zone_' + zone_id,
+                TEAM_NAME: team_name,
+            });
+        }
+
         teamTLAs=match.teams;
+
+        let content = '';
+        const zonesContainer = document.querySelector('#zones ul');
 
         for (cornerID in teamTLAs)
         {
             let TLA = teamTLAs[cornerID]
             if(TLA==null || TLA=="???")
             {
-                $("#zones .zone_"+cornerID+" p").text("-EMPTY-");
+                content += buildZone(cornerID, "-EMPTY-");
             }
             else
             {
                 let teamName = teams[TLA].name
-                $("#zones .zone_"+cornerID+" p").text(TLA+": "+teamName);
+                content += buildZone(cornerID, TLA+": "+teamName);
             }
         }
+        zonesContainer.innerHTML = content;
     }
 }
 

--- a/stream.html
+++ b/stream.html
@@ -250,7 +250,6 @@ overlay.next={
                     teamImg = imgURI+teams[TLA].image_url
                 else
                     teamImg = ""
-                let teamImage = teams[TLA]
                 $(".team-next.zone_"+cornerID+" h2").text(TLA);
                 $(".team-next.zone_"+cornerID+" img").attr("src",teamImg);
             }

--- a/style.scss
+++ b/style.scss
@@ -2,14 +2,9 @@
 $background: #00ff00;
 
 $white: white;
-$dark: #2a2a2a;
+$dark: #2a2a2a;  // Updating this? Also update the linear-gradient target in the #corners-css template.
 
 $brand: #3270ed;
-
-$zone_0: #00ff00;
-$zone_1: #ff6600;
-$zone_2: #ff00ff;
-$zone_3: #ffff00;
 
 $chroma_key: #ff6600;
 
@@ -91,19 +86,8 @@ p {
 .sbox-med::before {
 	@extend sbox_before;
 }
-.purple::before {
-	background: linear-gradient(to right,$zone_0,$dark 50px) !important;
-}
-.green::before {
-	background: linear-gradient(to right,$zone_1,$dark 50px) !important;
-}
-.yellow::before {
-	background: linear-gradient(to right,$zone_2,$dark 50px) !important;
-}
-.orange::before {
-	background: linear-gradient(to right,$zone_3,$dark 50px) !important;
-}
 .flair::before {
+	// Updating this? Also update the similar corner flairs defined in the #corners-css template.
 	background: linear-gradient(to left,$brand,$dark 50px) !important;
 }
 #overlay-top {

--- a/style.scss
+++ b/style.scss
@@ -11,6 +11,8 @@ $zone_1: #ff6600;
 $zone_2: #ff00ff;
 $zone_3: #ffff00;
 
+$chroma_key: #ff6600;
+
 @import url('https://fonts.googleapis.com/css?family=Open+Sans');
 $font: 'Open Sans', sans-serif;
 
@@ -40,7 +42,7 @@ sbox_content {
 body {
 	padding: 0;
 	margin: 0;
-	background: $zone_1;
+	background: $chroma_key;
 }
 @font-face {
 	font-family: $font;


### PR DESCRIPTION
There are two parts to this:
- generalise zone colours to come from the API
- generalise the display of teams in zones, so that the number of zones is determined by the match data

Together these move the responsibility for the arena definition into the API, rather than hardcoding it into the overlay.

Fixes https://github.com/srobo/competition-team-minutes/issues/256