### PR TITLE
Reload matches when the last-scored-match changes

### DIFF
--- a/events.js
+++ b/events.js
@@ -28,12 +28,6 @@ if (!!window.EventSource) {
     }
   }, false);
 
-  eventSource.addEventListener('matches', function(e){
-    if (typeof onMatchesUpdate == 'function') {
-        onMatchesUpdate(JSON.parse(e.data));
-    }
-  }, false);
-
   eventSource.addEventListener('match', function(e){
     if (typeof onMatchUpdate == 'function') {
         onMatchUpdate(JSON.parse(e.data));

--- a/stream.html
+++ b/stream.html
@@ -696,8 +696,8 @@ onDelayUpdate = function() {
     comp.matches(recievedMatches);
 }
 
-onMatchesUpdate = function() {
-    console.log("updated matches, reloading matches");
+onLastScoredMatchUpdate = function() {
+    console.log("updated last-scored-match, reloading matches");
     comp.matches(recievedMatches);
 }
 


### PR DESCRIPTION
During the knockouts the scoring of matches changes the participants of later matches, so we should reload the schedule at that point.

Fixes https://github.com/srobo/livestream-overlay/issues/33

Note: https://github.com/srobo/livestream-overlay/pull/34 did in fact not fix that issue as there is no 'matches' event.

Have tested that this reloads the scheduled at the expected time.